### PR TITLE
fix future warning throw by scipy 1.17.0 about data types

### DIFF
--- a/src/openmcmc/parameter.py
+++ b/src/openmcmc/parameter.py
@@ -533,4 +533,6 @@ class MixtureParameterMatrix(MixtureParameter):
             (np.ndarray): unscaled precision matrix
 
         """
-        return sparse.diags(diagonals=self.get_element_match(state, element_index).flatten(), offsets=0, format="csc")
+        return sparse.diags(
+            diagonals=self.get_element_match(state, element_index).flatten(), offsets=0, format="csc", dtype=np.float64
+        )


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Shell Global Solutions International B.V. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0
-->

# Description

Scipy 1.17.0 is throwing a warning about conversion of data types in sparse.diags which affects parameter.py and giving many wanrings in testing.

Fixes # (issue)

Fix is to force the dtype not to let it figure it out.

From Scipy Documentation:

"Up until SciPy 1.19, the default behavior will be to return a matrix with an inexact (floating point) data type. In particular, integer input will be converted to double precision floating point. This behavior is deprecated, and in SciPy 1.19, the default behavior will be changed to return a matrix with the same data type as the input diagonals. To adopt this behavior before version 1.19, use dtype=None."


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing is unchanged but this removes several warnings in the unit testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

